### PR TITLE
changed test func to SmokeTest and light dox

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,22 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   1. If no Elastic Beanstalk envrionments currently exist, then create one, assign it the "active" cname prefix and deploy the application there
   2. If one Elastic Beanstalk environment currently exists, assert that it currently has the "active" cname prefix, then create a new environment, assign it the "inactive" cname prefix and deploy the application there
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
-3. Run smoke tests against the target environment
-4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
-
+3. Run smoke tests against the target environment. SmokeTest is configured using the optional SmokeTest function and expects a method signature of function (url, callback). The url parameter will be populated with the url of the new environment prior to cname switching. The callback is used to notify the deployment strategy of any errors and halt the deployment.
 ``` javascript
-  // Optional SmokeTest function allows for the testing of the new inactive environment prior to cname swapping. Currently only supported in blue/green strategy.
   SmokeTest : function (url, callback){
     console.log("SmokeTest: smoke visible at %s", url);
-    return callback();
+    // ... do something to test the new version
+    if (err) {
+      // things have gone wrong, call the callback with useful error information
+      callback(err);
+    } else {
+      callback();
+    }
   }
 ```
+4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
+
+
 
 ## Custom deployment strategies
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ module.exports = {
     Version : ""
   },
 
+
+
   // Optionally specify a Cloud Formation template to deploy related resources along with your
   // Elastic Beanstalk app. This template will be used to create a separate Cloud Formation stack
   // for each Elastic Beanstalk environment. Common and environment specific tags will also be
@@ -113,6 +115,14 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
 3. Run smoke tests against the target environment
 4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
+
+``` javascript
+  // Optional SmokeTest function allows for the testing of the new inactive environment prior to cname swapping. Currently only supported in blue/green strategy.
+  SmokeTest : function (url, callback){
+    console.log("SmokeTest: smoke visible at %s", url);
+    return callback();
+  }
+```
 
 ## Custom deployment strategies
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
 3. Run smoke tests against the target environment. SmokeTest is configured using the optional SmokeTest function and expects a method signature of function (url, callback). The url parameter will be populated with the url of the new environment prior to cname switching. The callback is used to notify the deployment strategy of any errors and halt the deployment.
 
-        ``` javascript
+        ```javascript
           SmokeTest : function (url, callback){
             console.log("SmokeTest: smoke visible at %s", url);
             // ... do something to test the new version

--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
 3. Run smoke tests against the target environment. SmokeTest is configured using the optional SmokeTest function and expects a method signature of function (url, callback). The url parameter will be populated with the url of the new environment prior to cname switching. The callback is used to notify the deployment strategy of any errors and halt the deployment.
 
-        ```javascript
-          SmokeTest : function (url, callback){
-            console.log("SmokeTest: smoke visible at %s", url);
-            // ... do something to test the new version
-            if (err) {
-              // things have gone wrong, call the callback with useful error information
-              callback(err);
-            } else {
-              callback();
-            }
-          }
-        ```
+```javascript
+  SmokeTest : function (url, callback){
+    console.log("SmokeTest: smoke visible at %s", url);
+    // ... do something to test the new version
+    if (err) {
+      // things have gone wrong, call the callback with useful error information
+      callback(err);
+    } else {
+      callback();
+    }
+  }
+```
 4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
 
 

--- a/README.md
+++ b/README.md
@@ -114,18 +114,19 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   2. If one Elastic Beanstalk environment currently exists, assert that it currently has the "active" cname prefix, then create a new environment, assign it the "inactive" cname prefix and deploy the application there
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
 3. Run smoke tests against the target environment. SmokeTest is configured using the optional SmokeTest function and expects a method signature of function (url, callback). The url parameter will be populated with the url of the new environment prior to cname switching. The callback is used to notify the deployment strategy of any errors and halt the deployment.
-``` javascript
-  SmokeTest : function (url, callback){
-    console.log("SmokeTest: smoke visible at %s", url);
-    // ... do something to test the new version
-    if (err) {
-      // things have gone wrong, call the callback with useful error information
-      callback(err);
-    } else {
-      callback();
-    }
-  }
-```
+
+        ``` javascript
+          SmokeTest : function (url, callback){
+            console.log("SmokeTest: smoke visible at %s", url);
+            // ... do something to test the new version
+            if (err) {
+              // things have gone wrong, call the callback with useful error information
+              callback(err);
+            } else {
+              callback();
+            }
+          }
+        ```
 4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
 
 

--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ The currently supported blue/green deployment strategy effectively creates 2 Ela
   3. If two Elastic Beanstalk environments currently exist, assert which one is currently assigned the "inactive" cname prefix, terminate it, create a new environment with the "inactive" cname prefix and deploy the application there
 3. Run smoke tests against the target environment. SmokeTest is configured using the optional SmokeTest function and expects a method signature of function (url, callback). The url parameter will be populated with the url of the new environment prior to cname switching. The callback is used to notify the deployment strategy of any errors and halt the deployment.
 
-```javascript
-  SmokeTest : function (url, callback){
-    console.log("SmokeTest: smoke visible at %s", url);
-    // ... do something to test the new version
-    if (err) {
-      // things have gone wrong, call the callback with useful error information
-      callback(err);
-    } else {
-      callback();
-    }
-  }
-```
+    ```javascript
+      SmokeTest : function (url, callback){
+        console.log("SmokeTest: smoke visible at %s", url);
+        // ... do something to test the new version
+        if (err) {
+          // things have gone wrong, call the callback with useful error information
+          callback(err);
+        } else {
+          callback();
+        }
+      }
+    ```
 4. Assuming the smoke tests pass, execute cname swap, using Elastic Beanstalk's out of the box functionality
 
 

--- a/src/strategies/blue-green/states/running-tests.js
+++ b/src/strategies/blue-green/states/running-tests.js
@@ -8,7 +8,7 @@ module.exports = function(config, services, args) {
     return {
         activate : function(fsm, data) {
 
-            var test = config.test || function(url, callback) {
+            var test = config.SmokeTest || function(url, callback) {
                 l.info("requesting %s", url);
 
                 var count = 0;


### PR DESCRIPTION
Apologies on changing the interface but given the typo it was inevitable. I am taking liberties and suggesting a name change from Test to SmokeTest feels more explicit and mirrors the original implementation and adds possibility for other types of test functions.....but no idea what those would be.
